### PR TITLE
Adjust import in test

### DIFF
--- a/test/test.janet
+++ b/test/test.janet
@@ -1,6 +1,6 @@
 # A simple test application
 
-(import build/webview :as webview)
+(import ../build/webview :as webview)
 
 (def wv (webview/init
                       :title "Hacker News"


### PR DESCRIPTION
This PR adjusts the path used in `import` in `test.janet` to get `jpm test` working again.