### PR TITLE
Replace file/popen with os/spawn

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -7,16 +7,15 @@
 
 (defn shell
   "Helper for using pkg-config"
-  [str]
-  (def f (file/popen str))
-  (def output (file/read f :all))
-  (file/close f)
+  [cmd]
+  (def p (os/spawn (string/split " " cmd) :p {:in :pipe :out :pipe}))
+  (def output (:read (p :out) :all))
   (string/replace "\n" "" output))
 
 (def webview-def (case (os/which)
-  :windows "WEBVIEW_WINAPI"
-  :macos "WEBVIEW_COCOA"
-  "WEBVIEW_GTK"))
+                   :windows "WEBVIEW_WINAPI"
+                   :macos "WEBVIEW_COCOA"
+                   "WEBVIEW_GTK"))
 
 (defn parts
   "Split on whitespace."


### PR DESCRIPTION
`file/popen` has been removed. Using `os/spawn` instead to fix the build. 